### PR TITLE
Add and improve readmes throughout repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,42 @@
 # scVI and SCANVI Training Pipeline
 
-This repository provides a Python script for training and evaluating scVI and SCANVI models on single-cell RNA sequencing data. The script includes functionality for data preprocessing, model training, and result analysis.
+This repository contains a Snakemake workflow and helper scripts for training [scVI](https://scvi-tools.org/) and SCANVI models on single-cell RNA sequencing data.
+The pipeline performs data preprocessing, model training, benchmarking and differential expression analyses.
 
 ## Features
 
-* **Data Preprocessing:** Filters cells and genes, structures annotation labels, and removes mitochondrial genes.
-* **Model Training:** Trains scVI and SCANVI models with customizable parameters.
-* **Result Analysis:**  Extracts training metrics, performs differential expression analysis, and generates latent representations.
-* **Query Mapping:** Maps query datasets to the reference latent space using trained models.
-* **Integration Benchmarking:**  Evaluates the performance of different integration methods (PCA, Scanorama, Harmony, scVI, SCANVI).
+* **Data preprocessing** – filters cells and genes, manages annotation labels and removes mitochondrial genes.
+* **Model training** – trains scVI and SCANVI models with customizable parameters and checkpointing.
+* **Query mapping** – maps query data sets into a trained reference latent space.
+* **Benchmarking** – evaluates embeddings using PCA, Scanorama, Harmony, scVI and SCANVI.
+* **Result extraction** – exports training metrics and differential expression results.
 
-## Requirements
+## Installation
 
-* Python 3.8+
-* scVI
-* scanpy
-* anndata
-* scib-metrics
-* sklearn
-* torch
+Create the conda environment used by the workflow:
+
+```bash
+mamba env create -f environment.yml
+```
+
+Activate the environment before running the pipeline.
+
+## Usage
+
+Edit `config/config.yaml` to point to your input AnnData file and desired output directory.
+The workflow can then be executed locally with
+
+```bash
+snakemake --use-conda --cores 4 -s Snakefile
+```
+
+For HPC execution a Slurm profile is provided under `config/gpu` (see the README in that directory).
+
+Individual steps can also be run directly via the scripts in `scripts/`.
+
+## Repository layout
+
+* `scripts/` – Python scripts used in the workflow.
+* `config/` – configuration files and cluster profiles.
+* `notebooks/` – example notebooks exploring various parts of the pipeline.
+

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,9 @@
+# Configuration Files
+
+This directory holds configuration files used by the Snakemake workflow.
+
+- **`config.yaml`** – main configuration file specifying the `input_adata` path and the `output_path` directory where results will be written.
+- **`gpu.json`** – Slurm resource settings used by the cluster profile in `config/gpu`.
+- **`gpu/`** – Snakemake profile for running the workflow on an HPC cluster (see `config/gpu/README.md`).
+
+Edit `config.yaml` before running the pipeline to match your local paths.

--- a/config/gpu/README.md
+++ b/config/gpu/README.md
@@ -1,0 +1,14 @@
+# GPU Snakemake Profile
+
+The files in this directory define a Snakemake profile for running the workflow on a Slurm GPU cluster.
+
+- **`config.yaml`** sets default Snakemake command line options such as the cluster submission command and number of cores.
+- **`../gpu.json`** contains the resource specifications passed to `sbatch` (memory, wall time, number of GPUs, etc.).
+
+To launch the workflow with this profile use:
+
+```bash
+snakemake --profile config/gpu --use-conda --cores 36 -s workflow.smk
+```
+
+The `gpu_launcher.sh` script provides an example batch submission wrapper that copies the current `Snakefile` to `workflow.smk` before execution.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,9 @@
+# Notebooks
+
+This folder contains a few exploratory Jupyter notebooks:
+
+- **`checkpointing.ipynb`** – demonstrates how model checkpointing is handled during training.
+- **`generate_parameter_table.ipynb`** – utility notebook that constructs tables of hyperparameters for experiments.
+- **`test_ray.ipynb`** – small experiments for running parts of the pipeline with Ray.
+
+The notebooks assume the same Python environment as the main workflow.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# Scripts
+
+This folder contains standalone Python scripts that are used by the Snakemake workflow but can also be executed on their own.
+
+- **`train_model.py`** – preprocesses an AnnData object, trains scVI and SCANVI models and writes the resulting embeddings, models and metrics to the output directory. The script expects three arguments: the input `.h5ad` file, the number of highly variable genes and the output directory.
+- **`benchmark.py`** – benchmarks the latent representations of an integrated dataset using metrics from `scib-metrics`. It writes a CSV file with the results.
+- **`extract_deg.py`** – loads a trained SCANVI model and performs differential expression testing, writing the results to CSV.
+
+All scripts assume that the required Python packages listed in `environment.yml` are available.


### PR DESCRIPTION
## Summary
- expand root README with installation and usage notes
- document configuration files and cluster profile
- describe example notebooks and scripts

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68405aaddb388331b42261e9d99df9b7